### PR TITLE
build(action): update node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,6 @@ inputs:
     default: "https://install.determinate.systems/magic-nix-cache/perf"
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "./dist/index.js"
   post: "./dist/index.js"


### PR DESCRIPTION
##### Description

[node 16 is now being deprecated relative to node 20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ... 
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

https://github.com/DeterminateSystems/magic-nix-cache-action/blob/1402a2dd8f56a6a6306c015089c5086f5e1ca3ef/action.yml#L36

##### Checklist

- [ ] Tested changes against a test repository
  - see [ci run in fork](https://github.com/cameronraysmith/magic-nix-cache-action/actions/runs/7644817637)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)
