### PR TITLE
Better Boolean handling and debug statement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     permissions:
       id-token: "write"
       contents: "read"
+    env:
+      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: actions/checkout@v3
       - name: Install Nix
@@ -61,6 +63,8 @@ jobs:
     permissions:
       id-token: "write"
       contents: "read"
+    env:
+      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: actions/checkout@v3
       - name: Install Nix
@@ -82,6 +86,8 @@ jobs:
     permissions:
       id-token: "write"
       contents: "read"
+    env:
+      ACTIONS_STEP_DEBUG: true
     steps:
       - uses: actions/checkout@v3
       - name: Install Nix


### PR DESCRIPTION
Handling all Actions YAML inputs as strings seems quite brittle. Using `getBooleanInput` instead of plain old string-returning `getInput` seems like a wise move whenever true Booleans are in question.

I've also added a debugging statement for the full command being run to start the server.