### PR TITLE
Make the source-binary setting optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ inputs:
 
   source-binary:
     description: Run a version of the cache binary from somewhere already on disk. Conflicts with all other `source-*` options.
+    required: false
   source-branch:
     description: The branch of `magic-nix-cache` to use. Conflicts with all other `source-*` options.
     required: false


### PR DESCRIPTION
I'm hoping that this PR fixes [this](https://github.com/DeterminateSystems/magic-nix-cache/actions/runs/9198301716/job/25301293813?pr=70)