### PR TITLE
Add source-checksums-url, source-checksums-sha256 inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,16 @@ inputs:
   source-url:
     description: A URL pointing to a `magic-nix-cache` binary. Overrides all other `source-*` options.
     required: false
+  source-checksums-url:
+    description: |
+      URL of a `shasum`-format checksums file listing the SHA-256 of each artifact. Used together
+      with `source-checksums-sha256` to verify the downloaded installer.
+    required: false
+  source-checksums-sha256:
+    description: |
+      Pinned SHA-256 (hex) of the file served at `source-checksums-url`. Must be set together with
+      `source-checksums-url`.
+    required: false
   _internal-strict-mode:
     description: Whether to fail when any errors are thrown. Used only to test the Action; do not set this in your own workflows.
     required: false


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation
behind it
--->

##### Checklist

- [ ] Tested changes against a test repository
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] (If this PR is for a release) Updated README to point to the new tag (leave unchecked if not applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `source-checksums-url` input to provide a `shasum`-format checksums file URL for installer artifact verification.
  * Added `source-checksums-sha256` input to pin the SHA-256 hash of the checksums file (intended to be configured together with `source-checksums-url`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->